### PR TITLE
Abort explosion when team has no members

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -39,11 +39,8 @@ export = (app: Probot) => {
           .filter((login) => login !== pr.user.login),
       ).sort(randomize);
 
-      /** If the team(s) have no members, there is nobody to explode to.
-       * Abort before removing the team reviewers, otherwise the PR would be
-       * left with no requested reviewers at all. */
+      // skip if no team members to explode
       if (membersToAdd.length === 0) {
-        log.info("No team members to add, aborting explosion");
         return;
       }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,7 +39,7 @@ export = (app: Probot) => {
           .filter((login) => login !== pr.user.login),
       ).sort(randomize);
 
-      // skip if no team members to explode
+      /** Skip if no team members to explode */
       if (membersToAdd.length === 0) {
         return;
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,14 @@ export = (app: Probot) => {
           .filter((login) => login !== pr.user.login),
       ).sort(randomize);
 
+      /** If the team(s) have no members, there is nobody to explode to.
+       * Abort before removing the team reviewers, otherwise the PR would be
+       * left with no requested reviewers at all. */
+      if (membersToAdd.length === 0) {
+        log.info("No team members to add, aborting explosion");
+        return;
+      }
+
       /** Remove the teams */
       await octokit.pulls.removeRequestedReviewers({
         ...context.pullRequest(),


### PR DESCRIPTION
## What

Abort the explosion early when the requested team(s) have no members to add.

## Why

In `src/app.ts`, when a `pull_request.review_requested` event fires, the bot:

1. Lists the members of each requested team
2. Removes the team reviewer(s) from the PR
3. Requests each member individually

If a requested team has no members (or its only member is the PR author, who is filtered out), `membersToAdd` ends up empty. The bot would still remove the team reviewer and then call `requestReviewers` with an empty `reviewers` array — leaving the PR with **no requested reviewers at all**.

## Change

Before stripping the team reviewers, bail out if there is nobody to add:

```ts
if (membersToAdd.length === 0) {
  log.info("No team members to add, aborting explosion");
  return;
}
```

This leaves the original team review request untouched when there's nothing to explode to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)