### PR TITLE
Apply team blacklist filter to teamSlugs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ export = (app: Probot) => {
       let teamSlugs = pr.requested_teams.map((team) => team.slug);
 
       /** Check blacklist of team names, filter out blacklisted team names */
-      teamSlugs.filter(
+      teamSlugs = teamSlugs.filter(
         (slug) =>
           !BLACKLIST_PATTERNS.some((pattern) => Boolean(slug.match(pattern))),
       );

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import { Probot } from "probot"; // eslint-disable-line no-unused-vars
 
-const BLACKLIST_PATTERNS = ["ai.*review.*", ".*auggie.*"];
+const BLACKLIST_PATTERNS = [".*ai.*review.*", ".*auggie.*"];
 
 export = (app: Probot) => {
   app.on("pull_request.review_requested", async (context) => {


### PR DESCRIPTION
Fix the team blacklist so it actually filters out blacklisted teams.

Because the result is discarded, `teamSlugs` is unchanged and blacklisted teams (e.g. `ai.*review.*`, `.*auggie.*`) are still exploded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)